### PR TITLE
removed warning for wide range of GCC versions (5,6,7), fixes #9

### DIFF
--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -182,6 +182,7 @@ int QHotkeyPrivateX11::HotkeyErrorHandler::handleError(Display *display, XErrorE
 			errorString = QHotkeyPrivateX11::formatX11Error(display, error->error_code);
 			return 1;
 		}
+		Q_FALLTHROUGH();
 		// fall through
 	default:
 		return 0;

--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -172,8 +172,6 @@ QHotkeyPrivateX11::HotkeyErrorHandler::~HotkeyErrorHandler()
 
 int QHotkeyPrivateX11::HotkeyErrorHandler::handleError(Display *display, XErrorEvent *error)
 {
-QT_WARNING_PUSH
-QT_WARNING_DISABLE_GCC("-Wimplicit-fallthrough")
 	switch (error->error_code) {
 	case BadAccess:
 	case BadValue:
@@ -184,8 +182,8 @@ QT_WARNING_DISABLE_GCC("-Wimplicit-fallthrough")
 			errorString = QHotkeyPrivateX11::formatX11Error(display, error->error_code);
 			return 1;
 		}
+		// fall through
 	default:
 		return 0;
 	}
-QT_WARNING_POP
 }


### PR DESCRIPTION
removed macro which produces warning with GCC 5 or 6
and added simple comment instead of it (to disable warning produced by GCC 7)
fixes #9 