### PR TITLE
X11 Media Key Support

### DIFF
--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -21,6 +21,7 @@ protected:
 	// QHotkeyPrivate interface
 	quint32 nativeKeycode(Qt::Key keycode, bool &ok) Q_DECL_OVERRIDE;
 	quint32 nativeModifiers(Qt::KeyboardModifiers modifiers, bool &ok) Q_DECL_OVERRIDE;
+	QString getX11String(Qt::Key keycode);
 	bool registerShortcut(QHotkey::NativeShortcut shortcut) Q_DECL_OVERRIDE;
 	bool unregisterShortcut(QHotkey::NativeShortcut shortcut) Q_DECL_OVERRIDE;
 
@@ -63,9 +64,33 @@ bool QHotkeyPrivateX11::nativeEventFilter(const QByteArray &eventType, void *mes
 	return false;
 }
 
+QString QHotkeyPrivateX11::getX11String(Qt::Key keycode)
+{
+	switch(keycode){
+
+		case Qt::Key_MediaLast : 
+		case Qt::Key_MediaPrevious : 
+			return "XF86AudioPrev";
+		case Qt::Key_MediaNext : 
+			return "XF86AudioNext";
+		case Qt::Key_MediaPause : 
+		case Qt::Key_MediaPlay : 
+		case Qt::Key_MediaTogglePlayPause :
+			return "XF86AudioPlay";
+		case Qt::Key_MediaRecord :
+			return "XF86AudioRecord"; 
+		case Qt::Key_MediaStop : 
+			return "XF86AudioStop";
+		default :
+			return QKeySequence(keycode).toString(QKeySequence::NativeText);
+	}
+}
+
 quint32 QHotkeyPrivateX11::nativeKeycode(Qt::Key keycode, bool &ok)
 {
-	KeySym keysym = XStringToKeysym(QKeySequence(keycode).toString(QKeySequence::NativeText).toLatin1().constData());
+	QString keyString = getX11String(keycode);
+
+	KeySym keysym = XStringToKeysym(keyString.toLatin1().constData());
 	if (keysym == NoSymbol) {
 		//not found -> just use the key
 		if(keycode <= 0xFFFF)


### PR DESCRIPTION
Hey Skycoder,

I know this is not a very elegant solution and is basically a hacky workaround. But I'd really like to see support for media keys, and I don't want to ask without at least providing some sort of solution. [XFree86](http://wiki.linuxquestions.org/wiki/XFree86) are extensions to the keysymdef.h file that X11 lib includes, and is shipped with most major distributions. The problem here was that Qt keys don't map (even 1:1) to these, which makes XStringToKeysym() fail. That X method does load the XF86keysym.h file, however so these are valid keys on all OSs that include these definitions. 

If you'd be interested in extending support for media keys, I'd be happy to develop and test on X11 and Windows (don't have access to a Mac). I can employ similar solutions if you can't think of a better one, but I'd be happy to discuss better solutions as well.  Thanks!