### PR TITLE
Hotkey release signal

### DIFF
--- a/QHotkey/qhotkey.cpp
+++ b/QHotkey/qhotkey.cpp
@@ -264,9 +264,9 @@ void QHotkeyPrivate::activateShortcut(QHotkey::NativeShortcut shortcut)
 
 void QHotkeyPrivate::releaseShortcut(QHotkey::NativeShortcut shortcut)
 {
-       QMetaMethod signal = QMetaMethod::fromSignal(&QHotkey::released);
-       for(QHotkey *hkey : shortcuts.values(shortcut))
-               signal.invoke(hkey, Qt::QueuedConnection);
+	QMetaMethod signal = QMetaMethod::fromSignal(&QHotkey::released);
+	for(QHotkey *hkey : shortcuts.values(shortcut))
+		signal.invoke(hkey, Qt::QueuedConnection);
 }
 
 void QHotkeyPrivate::addMappingInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers, const QHotkey::NativeShortcut &nativeShortcut)

--- a/QHotkey/qhotkey.cpp
+++ b/QHotkey/qhotkey.cpp
@@ -262,6 +262,13 @@ void QHotkeyPrivate::activateShortcut(QHotkey::NativeShortcut shortcut)
 		signal.invoke(hkey, Qt::QueuedConnection);
 }
 
+void QHotkeyPrivate::releaseShortcut(QHotkey::NativeShortcut shortcut)
+{
+       QMetaMethod signal = QMetaMethod::fromSignal(&QHotkey::released);
+       for(QHotkey *hkey : shortcuts.values(shortcut))
+               signal.invoke(hkey, Qt::QueuedConnection);
+}
+
 void QHotkeyPrivate::addMappingInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers, const QHotkey::NativeShortcut &nativeShortcut)
 {
 	mapping.insert({keycode, modifiers}, nativeShortcut);

--- a/QHotkey/qhotkey.h
+++ b/QHotkey/qhotkey.h
@@ -100,8 +100,8 @@ signals:
 	//! Will be emitted if the shortcut is pressed
 	void activated(QPrivateSignal);
 
-  //! Will be emitted if the shortcut press is released
-  void released(QPrivateSignal);
+	//! Will be emitted if the shortcut press is released
+	void released(QPrivateSignal);
 
 	//! @notifyAcFn{QHotkey::registered}
 	void registeredChanged(bool registered);

--- a/QHotkey/qhotkey.h
+++ b/QHotkey/qhotkey.h
@@ -100,6 +100,9 @@ signals:
 	//! Will be emitted if the shortcut is pressed
 	void activated(QPrivateSignal);
 
+  //! Will be emitted if the shortcut press is released
+  void released(QPrivateSignal);
+
 	//! @notifyAcFn{QHotkey::registered}
 	void registeredChanged(bool registered);
 

--- a/QHotkey/qhotkey_p.h
+++ b/QHotkey/qhotkey_p.h
@@ -25,6 +25,7 @@ public:
 
 protected:
 	void activateShortcut(QHotkey::NativeShortcut shortcut);
+	void releaseShortcut(QHotkey::NativeShortcut shortcut);
 
 	virtual quint32 nativeKeycode(Qt::Key keycode, bool &ok) = 0;//platform implement
 	virtual quint32 nativeModifiers(Qt::KeyboardModifiers modifiers, bool &ok) = 0;//platform implement

--- a/QHotkey/qhotkey_win.cpp
+++ b/QHotkey/qhotkey_win.cpp
@@ -28,6 +28,11 @@ private:
 };
 NATIVE_INSTANCE(QHotkeyPrivateWin)
 
+QHotkeyPrivateWin::QHotkeyPrivateWin(){
+	pollTimer.setInterval(50);
+	connect(&pollTimer, &QTimer::timeout, this, &QHotkeyPrivateWin::pollForHotkeyRelease);
+}
+
 bool QHotkeyPrivate::isPlatformSupported()
 {
 	return true;

--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QX11Info>
 #include <QThreadStorage>
+#include <QTimer>
 #include <X11/Xlib.h>
 #include <xcb/xcb.h>
 
@@ -41,6 +42,9 @@ private:
 
 	private:
 		XErrorHandler prevHandler;
+		xcb_key_press_event_t prevHandledEvent;
+		xcb_key_press_event_t prevEvent;
+		QTimer *releaseTimer = nullptr;
 
 		static int handleError(Display *display, XErrorEvent *error);
 	};
@@ -62,8 +66,27 @@ bool QHotkeyPrivateX11::nativeEventFilter(const QByteArray &eventType, void *mes
 
 	xcb_generic_event_t *genericEvent = static_cast<xcb_generic_event_t *>(message);
 	if (genericEvent->response_type == XCB_KEY_PRESS) {
-		xcb_key_press_event_t *keyEvent = static_cast<xcb_key_press_event_t *>(message);
-		this->activateShortcut({keyEvent->detail, keyEvent->state & QHotkeyPrivateX11::validModsMask});
+		xcb_key_press_event_t keyEvent = *static_cast<xcb_key_press_event_t *>(message);
+		this->prevEvent = keyEvent;
+		if (this->prevHandledEvent.response_type == XCB_KEY_RELEASE) {
+			if(this->prevHandledEvent.time == keyEvent.time) return false;
+		}
+		this->activateShortcut({keyEvent.detail, keyEvent.state & QHotkeyPrivateX11::validModsMask});
+	} else if (genericEvent->response_type == XCB_KEY_RELEASE) {
+		xcb_key_release_event_t keyEvent = *static_cast<xcb_key_release_event_t *>(message);
+		this->prevEvent = keyEvent;
+		QTimer *timer = new QTimer(this);
+		timer->setSingleShot(true);
+		timer->setInterval(50);
+		connect(timer, &QTimer::timeout, this, [this, keyEvent, timer] {
+			if(this->prevEvent.time == keyEvent.time && this->prevEvent.response_type == keyEvent.response_type && this->prevEvent.detail == keyEvent.detail){
+				this->releaseShortcut({keyEvent.detail, keyEvent.state & QHotkeyPrivateX11::validModsMask});
+			}
+			delete timer;
+		});
+		timer->start();
+		this->releaseTimer = timer;
+		this->prevHandledEvent = keyEvent;
 	}
 
 	return false;

--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -29,7 +29,10 @@ protected:
 private:
 	static const QVector<quint32> specialModifiers;
 	static const quint32 validModsMask;
-
+	XErrorHandler prevHandler;
+	xcb_key_press_event_t prevHandledEvent;
+	xcb_key_press_event_t prevEvent;
+	
 	static QString formatX11Error(Display *display, int errorCode);
 
 	class HotkeyErrorHandler {
@@ -41,9 +44,6 @@ private:
 		static QString errorString;
 
 	private:
-		XErrorHandler prevHandler;
-		xcb_key_press_event_t prevHandledEvent;
-		xcb_key_press_event_t prevEvent;
 		QTimer *releaseTimer = nullptr;
 
 		static int handleError(Display *display, XErrorEvent *error);


### PR DESCRIPTION
Adds support for a hotkey release signal, using kEventHotKeyReleased on Mac, XCB_KEY_RELEASE and polling to ignore repeats on X11 and polling on Windows.