### PR TITLE
fix include path in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(qhotkey ${LIBS})
 
 target_include_directories(qhotkey
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/QHotkey>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/QHotkey>
         $<INSTALL_INTERFACE:include>)
 
 set_target_properties(qhotkey PROPERTIES


### PR DESCRIPTION
The include path is not set correctly when QHotkey is build as a
subdirectory. Consider the following project structure:

~~~
my_project
├── 3rdparty
│   ├──  QHotkey
│   └──  ... other deps
├── CMakeLists.txt # Main build targets, includes 3rdparty/QHotkey with 'add_subdirectory'
└──  ...
~~~

When this is built, `CMAKE_SOURCE_DIR` refers to `my_project`, so the QHotkey header is not found by the targets defined in `my_project/CMakeLists.txt`. Using `CMAKE_CURRENT_SOURCE_DIR`  in `target_include_directories` should fix this.