### PR TITLE
Improve CMake rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.1)
 
 project(qhotkey VERSION 1.2.2 LANGUAGES CXX)
 
-option(QHOTKEY_EXAMPLES "Build examples" ON)
+option(QHOTKEY_EXAMPLES "Build examples" OFF)
+option(QHOTKEY_INSTALL "Enable install rule" ON)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -53,18 +54,20 @@ if(QHOTKEY_EXAMPLES)
     add_subdirectory(HotkeyTest)
 endif()
 
-include(GNUInstallDirs)
-set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/QHotkey)
+if(QHOTKEY_INSTALL)
+    include(GNUInstallDirs)
+    set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/QHotkey)
 
-install(
-    TARGETS qhotkey EXPORT QHotkeyConfig
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES
-    ${CMAKE_SOURCE_DIR}/QHotkey/qhotkey.h
-    ${CMAKE_SOURCE_DIR}/QHotkey/QHotkey
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/)
-install(EXPORT QHotkeyConfig DESTINATION ${INSTALL_CONFIGDIR})
+    install(
+        TARGETS qhotkey EXPORT QHotkeyConfig
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/QHotkey/qhotkey.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/QHotkey/QHotkey
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/)
+    install(EXPORT QHotkeyConfig DESTINATION ${INSTALL_CONFIGDIR})
 
-export(TARGETS qhotkey FILE QHotkeyConfig.cmake)
+    export(TARGETS qhotkey FILE QHotkeyConfig.cmake)
+endif()


### PR DESCRIPTION
* Disable building examples by default. Let me now if you not agree with it.
* Use `CMAKE_CURRENT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR`. Otherwise you will have an error if you will build the project as a sub-directory of another.
* Add an option to disable install rules. This is needed if user want to use this library as a static.