### PR TITLE
Improve error messages

### DIFF
--- a/QHotkey/qhotkey.cpp
+++ b/QHotkey/qhotkey.cpp
@@ -279,8 +279,10 @@ bool QHotkeyPrivate::addShortcutInvoked(QHotkey *hotkey)
 	QHotkey::NativeShortcut shortcut = hotkey->_nativeShortcut;
 
 	if(!shortcuts.contains(shortcut)) {
-		if(!registerShortcut(shortcut))
+		if(!registerShortcut(shortcut)) {
+			qCWarning(logQHotkey) << QHotkey::tr("Failed to register %1. Error: %2").arg(hotkey->shortcut().toString(), error);
 			return false;
+		}
 	}
 
 	shortcuts.insert(shortcut, hotkey);
@@ -296,9 +298,13 @@ bool QHotkeyPrivate::removeShortcutInvoked(QHotkey *hotkey)
 		return false;
 	hotkey->_registered = false;
 	emit hotkey->registeredChanged(true);
-	if(shortcuts.count(shortcut) == 0)
-		return unregisterShortcut(shortcut);
-	else
+	if(shortcuts.count(shortcut) == 0) {
+		if (!unregisterShortcut(shortcut)) {
+			qCWarning(logQHotkey) << QHotkey::tr("Failed to unregister %1. Error: %2").arg(hotkey->shortcut().toString(), error);
+			return false;
+		} else
+			return true;
+	} else
 		return true;
 }
 

--- a/QHotkey/qhotkey_mac.cpp
+++ b/QHotkey/qhotkey_mac.cpp
@@ -227,8 +227,7 @@ bool QHotkeyPrivateMac::registerShortcut(QHotkey::NativeShortcut shortcut)
 										  0,
 										  &eventRef);
 	if (status != noErr) {
-		qCWarning(logQHotkey) << "Failed to register hotkey. Error:"
-							  << status;
+		error = QString::number(status);
 		return false;
 	} else {
 		this->hotkeyRefs.insert(shortcut, eventRef);
@@ -241,8 +240,7 @@ bool QHotkeyPrivateMac::unregisterShortcut(QHotkey::NativeShortcut shortcut)
 	EventHotKeyRef eventRef = QHotkeyPrivateMac::hotkeyRefs.value(shortcut);
 	OSStatus status = UnregisterEventHotKey(eventRef);
 	if (status != noErr) {
-		qCWarning(logQHotkey) << "Failed to unregister hotkey. Error:"
-							  << status;
+		error = QString::number(status);
 		return false;
 	} else {
 		this->hotkeyRefs.remove(shortcut);

--- a/QHotkey/qhotkey_p.h
+++ b/QHotkey/qhotkey_p.h
@@ -33,6 +33,8 @@ protected:
 	virtual bool registerShortcut(QHotkey::NativeShortcut shortcut) = 0;//platform implement
 	virtual bool unregisterShortcut(QHotkey::NativeShortcut shortcut) = 0;//platform implement
 
+	QString error;
+
 private:
 	QHash<QPair<Qt::Key, Qt::KeyboardModifiers>, QHotkey::NativeShortcut> mapping;
 	QMultiHash<QHotkey::NativeShortcut, QHotkey*> shortcuts;

--- a/QHotkey/qhotkey_win.cpp
+++ b/QHotkey/qhotkey_win.cpp
@@ -267,8 +267,7 @@ bool QHotkeyPrivateWin::registerShortcut(QHotkey::NativeShortcut shortcut)
 	if(ok)
 		return true;
 	else {
-		qCWarning(logQHotkey) << "Failed to register hotkey. Error:"
-							  << qPrintable(QHotkeyPrivateWin::formatWinError(::GetLastError()));
+		error = QHotkeyPrivateWin::formatWinError(::GetLastError());
 		return false;
 	}
 }
@@ -279,8 +278,7 @@ bool QHotkeyPrivateWin::unregisterShortcut(QHotkey::NativeShortcut shortcut)
 	if(ok)
 		return true;
 	else {
-		qCWarning(logQHotkey) << "Failed to unregister hotkey. Error:"
-							  << qPrintable(QHotkeyPrivateWin::formatWinError(::GetLastError()));
+		error = QHotkeyPrivateWin::formatWinError(::GetLastError());
 		return false;
 	}
 }

--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -170,8 +170,7 @@ bool QHotkeyPrivateX11::registerShortcut(QHotkey::NativeShortcut shortcut)
 	XSync(display, False);
 
 	if(errorHandler.hasError) {
-		qCWarning(logQHotkey) << "Failed to register hotkey. Error:"
-							  << qPrintable(errorHandler.errorString);
+		error = errorHandler.errorString;
 		this->unregisterShortcut(shortcut);
 		return false;
 	} else
@@ -194,8 +193,7 @@ bool QHotkeyPrivateX11::unregisterShortcut(QHotkey::NativeShortcut shortcut)
 	XSync(display, False);
 
 	if(errorHandler.hasError) {
-		qCWarning(logQHotkey) << "Failed to unregister hotkey. Error:"
-							  << qPrintable(errorHandler.errorString);
+		error = errorHandler.errorString;
 		return false;
 	} else
 		return true;


### PR DESCRIPTION
* Show shortcut in errors.
* Make errors translatable.

Before:
```
QHotkey: Failed to register hotkey. Error: BadAccess (attempt to access private resource denied)
QHotkey: Failed to unregister hotkey. Error: BadAccess (attempt to access private resource denied)
QHotkey: Failed to register hotkey. Error: BadAccess (attempt to access private resource denied)
QHotkey: Failed to unregister hotkey. Error: BadAccess (attempt to access private resource denied)
QHotkey: Failed to register hotkey. Error: BadAccess (attempt to access private resource denied)
```
After:
```
QHotkey: "Failed to register Ctrl+Alt+E. Error: BadAccess (attempt to access private resource denied)"
QHotkey: "Failed to register Ctrl+Alt+S. Error: BadAccess (attempt to access private resource denied)"
QHotkey: "Failed to register Ctrl+Alt+G. Error: BadAccess (attempt to access private resource denied)"
QHotkey: "Failed to register Ctrl+Alt+F. Error: BadAccess (attempt to access private resource denied)"
QHotkey: "Failed to register Ctrl+Alt+C. Error: BadAccess (attempt to access private resource denied)"
```

Also users will be less confused (https://github.com/crow-translate/crow-translate/issues/149).