### PR TITLE
Fix Clang Tidy warnings

### DIFF
--- a/QHotkey/qhotkey.cpp
+++ b/QHotkey/qhotkey.cpp
@@ -8,7 +8,7 @@
 
 Q_LOGGING_CATEGORY(logQHotkey, "QHotkey")
 
-void QHotkey::addGlobalMapping(const QKeySequence &shortcut, const QHotkey::NativeShortcut &nativeShortcut)
+void QHotkey::addGlobalMapping(const QKeySequence &shortcut, QHotkey::NativeShortcut nativeShortcut)
 {
 	QMetaObject::invokeMethod(QHotkeyPrivate::instance(), "addMappingInvoked", Qt::QueuedConnection,
 							  Q_ARG(Qt::Key, Qt::Key(shortcut[0] & ~Qt::KeyboardModifierMask)),
@@ -40,7 +40,7 @@ QHotkey::QHotkey(Qt::Key keyCode, Qt::KeyboardModifiers modifiers, bool autoRegi
 	setShortcut(keyCode, modifiers, autoRegister);
 }
 
-QHotkey::QHotkey(const QHotkey::NativeShortcut &shortcut, bool autoRegister, QObject *parent) :
+QHotkey::QHotkey(QHotkey::NativeShortcut shortcut, bool autoRegister, QObject *parent) :
 	QHotkey(parent)
 {
 	setNativeShortcut(shortcut, autoRegister);
@@ -263,7 +263,7 @@ void QHotkeyPrivate::releaseShortcut(QHotkey::NativeShortcut shortcut)
 		signal.invoke(hkey, Qt::QueuedConnection);
 }
 
-void QHotkeyPrivate::addMappingInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers, const QHotkey::NativeShortcut &nativeShortcut)
+void QHotkeyPrivate::addMappingInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers, QHotkey::NativeShortcut nativeShortcut)
 {
 	mapping.insert({keycode, modifiers}, nativeShortcut);
 }
@@ -335,26 +335,26 @@ bool QHotkey::NativeShortcut::isValid() const
 	return valid;
 }
 
-bool QHotkey::NativeShortcut::operator ==(const QHotkey::NativeShortcut &other) const
+bool QHotkey::NativeShortcut::operator ==(QHotkey::NativeShortcut other) const
 {
 	return (key == other.key) &&
 		   (modifier == other.modifier) &&
 		   valid == other.valid;
 }
 
-bool QHotkey::NativeShortcut::operator !=(const QHotkey::NativeShortcut &other) const
+bool QHotkey::NativeShortcut::operator !=(QHotkey::NativeShortcut other) const
 {
 	return (key != other.key) ||
 		   (modifier != other.modifier) ||
 		   valid != other.valid;
 }
 
-uint qHash(const QHotkey::NativeShortcut &key)
+uint qHash(QHotkey::NativeShortcut key)
 {
 	return qHash(key.key) ^ qHash(key.modifier);
 }
 
-uint qHash(const QHotkey::NativeShortcut &key, uint seed)
+uint qHash(QHotkey::NativeShortcut key, uint seed)
 {
 	return qHash(key.key, seed) ^ qHash(key.modifier, seed);
 }

--- a/QHotkey/qhotkey.cpp
+++ b/QHotkey/qhotkey.cpp
@@ -25,14 +25,13 @@ QHotkey::QHotkey(QObject *parent) :
 	QObject(parent),
 	_keyCode(Qt::Key_unknown),
 	_modifiers(Qt::NoModifier),
-	_nativeShortcut(),
 	_registered(false)
 {}
 
-QHotkey::QHotkey(const QKeySequence &sequence, bool autoRegister, QObject *parent) :
+QHotkey::QHotkey(const QKeySequence &shortcut, bool autoRegister, QObject *parent) :
 	QHotkey(parent)
 {
-	setShortcut(sequence, autoRegister);
+	setShortcut(shortcut, autoRegister);
 }
 
 QHotkey::QHotkey(Qt::Key keyCode, Qt::KeyboardModifiers modifiers, bool autoRegister, QObject *parent) :
@@ -57,8 +56,7 @@ QKeySequence QHotkey::shortcut() const
 {
 	if(_keyCode == Qt::Key_unknown)
 		return QKeySequence();
-	else
-		return QKeySequence(_keyCode | _modifiers);
+	return QKeySequence(static_cast<int>(_keyCode | _modifiers));
 }
 
 Qt::Key QHotkey::keyCode() const
@@ -83,9 +81,9 @@ bool QHotkey::isRegistered() const
 
 bool QHotkey::setShortcut(const QKeySequence &shortcut, bool autoRegister)
 {
-	if(shortcut.isEmpty()) {
+	if(shortcut.isEmpty())
 		return resetShortcut();
-	} else if(shortcut.count() > 1) {
+	if(shortcut.count() > 1) {
 		qCWarning(logQHotkey, "Keysequences with multiple shortcuts are not allowed! "
 							  "Only the first shortcut will be used!");
 	}
@@ -118,15 +116,14 @@ bool QHotkey::setShortcut(Qt::Key keyCode, Qt::KeyboardModifiers modifiers, bool
 	if(_nativeShortcut.isValid()) {
 		if(autoRegister)
 			return QHotkeyPrivate::instance()->addShortcut(this);
-		else
-			return true;
-	} else {
-		qCWarning(logQHotkey) << "Unable to map shortcut to native keys. Key:" << keyCode << "Modifiers:" << modifiers;
-		_keyCode = Qt::Key_unknown;
-		_modifiers = Qt::NoModifier;
-		_nativeShortcut = NativeShortcut();
-		return false;
+		return true;
 	}
+
+	qCWarning(logQHotkey) << "Unable to map shortcut to native keys. Key:" << keyCode << "Modifiers:" << modifiers;
+	_keyCode = Qt::Key_unknown;
+	_modifiers = Qt::NoModifier;
+	_nativeShortcut = NativeShortcut();
+	return false;
 }
 
 bool QHotkey::resetShortcut()
@@ -158,35 +155,32 @@ bool QHotkey::setNativeShortcut(QHotkey::NativeShortcut nativeShortcut, bool aut
 		_nativeShortcut = nativeShortcut;
 		if(autoRegister)
 			return QHotkeyPrivate::instance()->addShortcut(this);
-		else
-			return true;
-	} else {
-		_keyCode = Qt::Key_unknown;
-		_modifiers = Qt::NoModifier;
-		_nativeShortcut = NativeShortcut();
 		return true;
-	}
+	} 
+
+	_keyCode = Qt::Key_unknown;
+	_modifiers = Qt::NoModifier;
+	_nativeShortcut = NativeShortcut();
+	return true;
 }
 
 bool QHotkey::setRegistered(bool registered)
 {
 	if(_registered && !registered)
 		return QHotkeyPrivate::instance()->removeShortcut(this);
-	else if(!_registered && registered) {
+	if(!_registered && registered) {
 		if(!_nativeShortcut.isValid())
 			return false;
-		else
-			return QHotkeyPrivate::instance()->addShortcut(this);
-	} else
-		return true;
+		return QHotkeyPrivate::instance()->addShortcut(this);
+	}
+	return true;
 }
 
 
 
 // ---------- QHotkeyPrivate implementation ----------
 
-QHotkeyPrivate::QHotkeyPrivate() :
-	shortcuts()
+QHotkeyPrivate::QHotkeyPrivate()
 {
 	Q_ASSERT_X(qApp, Q_FUNC_INFO, "QHotkey requires QCoreApplication to be instantiated");
 	qApp->eventDispatcher()->installNativeEventFilter(this);
@@ -211,8 +205,8 @@ QHotkey::NativeShortcut QHotkeyPrivate::nativeShortcut(Qt::Key keycode, Qt::Keyb
 								  Q_ARG(Qt::Key, keycode),
 								  Q_ARG(Qt::KeyboardModifiers, modifiers))) {
 		return QHotkey::NativeShortcut();
-	} else
-		return res;
+	}
+	return res;
 }
 
 bool QHotkeyPrivate::addShortcut(QHotkey *hotkey)
@@ -228,11 +222,11 @@ bool QHotkeyPrivate::addShortcut(QHotkey *hotkey)
 								  Q_RETURN_ARG(bool, res),
 								  Q_ARG(QHotkey*, hotkey))) {
 		return false;
-	} else {
-		if(res)
-			emit hotkey->registeredChanged(true);
-		return res;
 	}
+
+	if(res)
+		emit hotkey->registeredChanged(true);
+	return res;
 }
 
 bool QHotkeyPrivate::removeShortcut(QHotkey *hotkey)
@@ -248,11 +242,11 @@ bool QHotkeyPrivate::removeShortcut(QHotkey *hotkey)
 								  Q_RETURN_ARG(bool, res),
 								  Q_ARG(QHotkey*, hotkey))) {
 		return false;
-	} else {
-		if(res)
-			emit hotkey->registeredChanged(false);
-		return res;
 	}
+
+	if(res)
+		emit hotkey->registeredChanged(false);
+	return res;
 }
 
 void QHotkeyPrivate::activateShortcut(QHotkey::NativeShortcut shortcut)
@@ -302,10 +296,10 @@ bool QHotkeyPrivate::removeShortcutInvoked(QHotkey *hotkey)
 		if (!unregisterShortcut(shortcut)) {
 			qCWarning(logQHotkey) << QHotkey::tr("Failed to unregister %1. Error: %2").arg(hotkey->shortcut().toString(), error);
 			return false;
-		} else
-			return true;
-	} else
+		}
 		return true;
+	}
+	return true;
 }
 
 QHotkey::NativeShortcut QHotkeyPrivate::nativeShortcutInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers)
@@ -313,13 +307,13 @@ QHotkey::NativeShortcut QHotkeyPrivate::nativeShortcutInvoked(Qt::Key keycode, Q
 	if(mapping.contains({keycode, modifiers}))
 		return mapping.value({keycode, modifiers});
 
-	bool ok1, ok2 = false;
+	bool ok1 = false;
 	auto k = nativeKeycode(keycode, ok1);
+	bool ok2 = false;
 	auto m = nativeModifiers(modifiers, ok2);
 	if(ok1 && ok2)
 		return {k, m};
-	else
-		return {};
+	return {};
 }
 
 

--- a/QHotkey/qhotkey.h
+++ b/QHotkey/qhotkey.h
@@ -68,7 +68,7 @@ public:
 	explicit QHotkey(Qt::Key keyCode, Qt::KeyboardModifiers modifiers, bool autoRegister = false, QObject *parent = nullptr);
 	//! Constructs a hotkey from a native shortcut and optionally registers it
 	explicit QHotkey(const NativeShortcut &shortcut, bool autoRegister = false, QObject *parent = nullptr);
-	~QHotkey();
+	~QHotkey() override;
 
 	//! @readAcFn{QHotkey::registered}
 	bool isRegistered() const;

--- a/QHotkey/qhotkey.h
+++ b/QHotkey/qhotkey.h
@@ -46,16 +46,16 @@ public:
 		bool isValid() const;
 
 		//! Equality operator
-		bool operator ==(const NativeShortcut &other) const;
+		bool operator ==(NativeShortcut other) const;
 		//! Inequality operator
-		bool operator !=(const NativeShortcut &other) const;
+		bool operator !=(NativeShortcut other) const;
 
 	private:
 		bool valid;
 	};
 
 	//! Adds a global mapping of a key sequence to a replacement native shortcut
-	static void addGlobalMapping(const QKeySequence &shortcut, const NativeShortcut &nativeShortcut);
+	static void addGlobalMapping(const QKeySequence &shortcut, NativeShortcut nativeShortcut);
 
 	//! Checks if global shortcuts are supported by the current platform
 	static bool isPlatformSupported();
@@ -67,7 +67,7 @@ public:
 	//! Constructs a hotkey with a key and modifiers and optionally registers it
 	explicit QHotkey(Qt::Key keyCode, Qt::KeyboardModifiers modifiers, bool autoRegister = false, QObject *parent = nullptr);
 	//! Constructs a hotkey from a native shortcut and optionally registers it
-	explicit QHotkey(const NativeShortcut &shortcut, bool autoRegister = false, QObject *parent = nullptr);
+	explicit QHotkey(NativeShortcut shortcut, bool autoRegister = false, QObject *parent = nullptr);
 	~QHotkey() override;
 
 	//! @readAcFn{QHotkey::registered}
@@ -94,7 +94,7 @@ public slots:
 	bool resetShortcut();
 
 	//! Set this hotkey to a native shortcut
-	bool setNativeShortcut(NativeShortcut nativeShortcut, bool autoRegister = false);
+	bool setNativeShortcut(QHotkey::NativeShortcut nativeShortcut, bool autoRegister = false);
 
 signals:
 	//! Will be emitted if the shortcut is pressed
@@ -114,8 +114,8 @@ private:
 	bool _registered;
 };
 
-uint QHOTKEY_SHARED_EXPORT qHash(const QHotkey::NativeShortcut &key);
-uint QHOTKEY_SHARED_EXPORT qHash(const QHotkey::NativeShortcut &key, uint seed);
+uint QHOTKEY_SHARED_EXPORT qHash(QHotkey::NativeShortcut key);
+uint QHOTKEY_SHARED_EXPORT qHash(QHotkey::NativeShortcut key, uint seed);
 
 QHOTKEY_SHARED_EXPORT Q_DECLARE_LOGGING_CATEGORY(logQHotkey)
 

--- a/QHotkey/qhotkey_p.h
+++ b/QHotkey/qhotkey_p.h
@@ -39,7 +39,7 @@ private:
 	QHash<QPair<Qt::Key, Qt::KeyboardModifiers>, QHotkey::NativeShortcut> mapping;
 	QMultiHash<QHotkey::NativeShortcut, QHotkey*> shortcuts;
 
-	Q_INVOKABLE void addMappingInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers, const QHotkey::NativeShortcut &nativeShortcut);
+	Q_INVOKABLE void addMappingInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers, QHotkey::NativeShortcut nativeShortcut);
 	Q_INVOKABLE bool addShortcutInvoked(QHotkey *hotkey);
 	Q_INVOKABLE bool removeShortcutInvoked(QHotkey *hotkey);
 	Q_INVOKABLE QHotkey::NativeShortcut nativeShortcutInvoked(Qt::Key keycode, Qt::KeyboardModifiers modifiers);

--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -98,17 +98,17 @@ QString QHotkeyPrivateX11::getX11String(Qt::Key keycode)
 
 		case Qt::Key_MediaLast :
 		case Qt::Key_MediaPrevious :
-			return "XF86AudioPrev";
+			return QStringLiteral("XF86AudioPrev");
 		case Qt::Key_MediaNext :
-			return "XF86AudioNext";
+			return QStringLiteral("XF86AudioNext");
 		case Qt::Key_MediaPause :
 		case Qt::Key_MediaPlay :
 		case Qt::Key_MediaTogglePlayPause :
-			return "XF86AudioPlay";
+			return QStringLiteral("XF86AudioPlay");
 		case Qt::Key_MediaRecord :
-			return "XF86AudioRecord";
+			return QStringLiteral("XF86AudioRecord");
 		case Qt::Key_MediaStop :
-			return "XF86AudioStop";
+			return QStringLiteral("XF86AudioStop");
 		default :
 			return QKeySequence(keycode).toString(QKeySequence::NativeText);
 	}

--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -29,7 +29,6 @@ protected:
 private:
 	static const QVector<quint32> specialModifiers;
 	static const quint32 validModsMask;
-	QTimer *releaseTimer = nullptr;
 	xcb_key_press_event_t prevHandledEvent;
 	xcb_key_press_event_t prevEvent;
 
@@ -75,17 +74,11 @@ bool QHotkeyPrivateX11::nativeEventFilter(const QByteArray &eventType, void *mes
 	} else if (genericEvent->response_type == XCB_KEY_RELEASE) {
 		xcb_key_release_event_t keyEvent = *static_cast<xcb_key_release_event_t *>(message);
 		this->prevEvent = keyEvent;
-		auto *timer = new QTimer(this);
-		timer->setSingleShot(true);
-		timer->setInterval(50);
-		connect(timer, &QTimer::timeout, this, [this, keyEvent, timer] {
+		QTimer::singleShot(50, [this, keyEvent] {
 			if(this->prevEvent.time == keyEvent.time && this->prevEvent.response_type == keyEvent.response_type && this->prevEvent.detail == keyEvent.detail){
 				this->releaseShortcut({keyEvent.detail, keyEvent.state & QHotkeyPrivateX11::validModsMask});
 			}
-			delete timer;
 		});
-		timer->start();
-		this->releaseTimer = timer;
 		this->prevHandledEvent = keyEvent;
 	}
 

--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -22,7 +22,7 @@ protected:
 	// QHotkeyPrivate interface
 	quint32 nativeKeycode(Qt::Key keycode, bool &ok) Q_DECL_OVERRIDE;
 	quint32 nativeModifiers(Qt::KeyboardModifiers modifiers, bool &ok) Q_DECL_OVERRIDE;
-	QString getX11String(Qt::Key keycode);
+	static QString getX11String(Qt::Key keycode);
 	bool registerShortcut(QHotkey::NativeShortcut shortcut) Q_DECL_OVERRIDE;
 	bool unregisterShortcut(QHotkey::NativeShortcut shortcut) Q_DECL_OVERRIDE;
 
@@ -64,7 +64,7 @@ bool QHotkeyPrivateX11::nativeEventFilter(const QByteArray &eventType, void *mes
 	Q_UNUSED(eventType)
 	Q_UNUSED(result)
 
-	xcb_generic_event_t *genericEvent = static_cast<xcb_generic_event_t *>(message);
+	auto *genericEvent = static_cast<xcb_generic_event_t *>(message);
 	if (genericEvent->response_type == XCB_KEY_PRESS) {
 		xcb_key_press_event_t keyEvent = *static_cast<xcb_key_press_event_t *>(message);
 		this->prevEvent = keyEvent;
@@ -75,7 +75,7 @@ bool QHotkeyPrivateX11::nativeEventFilter(const QByteArray &eventType, void *mes
 	} else if (genericEvent->response_type == XCB_KEY_RELEASE) {
 		xcb_key_release_event_t keyEvent = *static_cast<xcb_key_release_event_t *>(message);
 		this->prevEvent = keyEvent;
-		QTimer *timer = new QTimer(this);
+		auto *timer = new QTimer(this);
 		timer->setSingleShot(true);
 		timer->setInterval(50);
 		connect(timer, &QTimer::timeout, this, [this, keyEvent, timer] {
@@ -132,8 +132,8 @@ quint32 QHotkeyPrivateX11::nativeKeycode(Qt::Key keycode, bool &ok)
 		if(res != 0)
 			ok = true;
 		return res;
-	} else
-		return 0;
+	}
+	return 0;
 }
 
 quint32 QHotkeyPrivateX11::nativeModifiers(Qt::KeyboardModifiers modifiers, bool &ok)
@@ -173,8 +173,8 @@ bool QHotkeyPrivateX11::registerShortcut(QHotkey::NativeShortcut shortcut)
 		error = errorHandler.errorString;
 		this->unregisterShortcut(shortcut);
 		return false;
-	} else
-		return true;
+	}
+	return true;
 }
 
 bool QHotkeyPrivateX11::unregisterShortcut(QHotkey::NativeShortcut shortcut)
@@ -188,15 +188,15 @@ bool QHotkeyPrivateX11::unregisterShortcut(QHotkey::NativeShortcut shortcut)
 		XUngrabKey(display,
 				   shortcut.key,
 				   shortcut.modifier | specialMod,
-				   DefaultRootWindow(display));
+				   XDefaultRootWindow(display));
 	}
 	XSync(display, False);
 
-	if(errorHandler.hasError) {
-		error = errorHandler.errorString;
+	if(HotkeyErrorHandler::hasError) {
+		error = HotkeyErrorHandler::errorString;
 		return false;
-	} else
-		return true;
+	}
+	return true;
 }
 
 QString QHotkeyPrivateX11::formatX11Error(Display *display, int errorCode)


### PR DESCRIPTION
I fixed the following Clang Tidy warnings (found on my CI):
[readability-redundant-member-init](https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-member-init.html)
[readability-convert-member-functions-to-static](https://clang.llvm.org/extra/clang-tidy/checks/readability-convert-member-functions-to-static.html)
[modernize-use-auto](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-auto.html)
[readability-else-after-return](https://clang.llvm.org/extra/clang-tidy/checks/readability-else-after-return.html)
[readability-static-accessed-through-instance](https://clang.llvm.org/extra/clang-tidy/checks/readability-static-accessed-through-instance.html)
[readability-inconsistent-declaration-parameter-name](https://clang.llvm.org/extra/clang-tidy/checks/readability-inconsistent-declaration-parameter-name.html)