### PR TITLE
Add support for Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,27 @@ option(QHOTKEY_INSTALL "Enable install rule" ON)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
+set(QT_MAJOR 5 CACHE STRING "Qt major version to use")
 
-qt5_wrap_cpp(MOC_HEADERS
-    QHotkey/qhotkey.h
-    QHotkey/qhotkey_p.h)
+if(QT_MAJOR EQUAL 6)
+    find_package(Qt${QT_MAJOR} 6.2.0 COMPONENTS Core Widgets REQUIRED)
+else()
+    find_package(Qt${QT_MAJOR} COMPONENTS Core Widgets REQUIRED)
+endif()
+
+if(QT_MAJOR GREATER_EQUAL 6)
+    qt_wrap_cpp(MOC_HEADERS
+        QHotkey/qhotkey.h
+        QHotkey/qhotkey_p.h)
+else()
+    qt5_wrap_cpp(MOC_HEADERS
+        QHotkey/qhotkey.h
+        QHotkey/qhotkey_p.h)
+endif()
 
 set(LIBS
-    Qt5::Core
-    Qt5::Widgets)
+    Qt${QT_MAJOR}::Core
+    Qt${QT_MAJOR}::Widgets)
 
 set(SRC_FILES
     QHotkey/qhotkey.cpp)
@@ -30,10 +42,14 @@ elseif(WIN32)
     set(SRC_FILES ${SRC_FILES} QHotkey/qhotkey_win.cpp)
 else()
     find_package(X11 REQUIRED)
-    find_package(Qt5X11Extras REQUIRED)
+    if(QT_MAJOR GREATER_EQUAL 6)
+        set(LIBS ${LIBS} ${X11_LIBRARIES})
+    else()
+        find_package(Qt${QT_MAJOR}X11Extras REQUIRED)
+        set(LIBS ${LIBS} ${X11_LIBRARIES} Qt${QT_MAJOR}::X11Extras)
+    endif()
 
     include_directories(${X11_INCLUDE_DIR})
-    set(LIBS ${LIBS} ${X11_LIBRARIES} Qt5::X11Extras)
     set(SRC_FILES ${SRC_FILES} QHotkey/qhotkey_x11.cpp)
 endif()
 

--- a/HotkeyTest/CMakeLists.txt
+++ b/HotkeyTest/CMakeLists.txt
@@ -1,12 +1,17 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-qt5_wrap_ui(test_UI_HEADERS hottestwidget.ui)
-qt5_wrap_cpp(test_MOC_HEADERS hottestwidget.h)
+if(QT_MAJOR GREATER_EQUAL 6)
+    qt_wrap_ui(test_UI_HEADERS hottestwidget.ui)
+    qt_wrap_cpp(test_MOC_HEADERS hottestwidget.h)
+else()
+    qt5_wrap_ui(test_UI_HEADERS hottestwidget.ui)
+    qt5_wrap_cpp(test_MOC_HEADERS hottestwidget.h)
+endif()
 
 add_executable(HotkeyTest
     main.cpp
     hottestwidget.cpp
     ${test_UI_HEADERS}
     ${test_MOC_HEADERS})
-target_link_libraries(HotkeyTest Qt5::Widgets qhotkey)
+target_link_libraries(HotkeyTest Qt${QT_MAJOR}::Widgets qhotkey)
 target_include_directories(HotkeyTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/QHotkey/qhotkey.h
+++ b/QHotkey/qhotkey.h
@@ -16,6 +16,12 @@
 	#define QHOTKEY_SHARED_EXPORT
 #endif
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	#define QHOTKEY_HASH_SEED size_t
+#else
+	#define QHOTKEY_HASH_SEED uint
+#endif
+
 //! A class to define global, systemwide Hotkeys
 class QHOTKEY_SHARED_EXPORT QHotkey : public QObject
 {
@@ -115,7 +121,7 @@ private:
 };
 
 uint QHOTKEY_SHARED_EXPORT qHash(QHotkey::NativeShortcut key);
-uint QHOTKEY_SHARED_EXPORT qHash(QHotkey::NativeShortcut key, uint seed);
+QHOTKEY_HASH_SEED QHOTKEY_SHARED_EXPORT qHash(QHotkey::NativeShortcut key, QHOTKEY_HASH_SEED seed);
 
 QHOTKEY_SHARED_EXPORT Q_DECLARE_LOGGING_CATEGORY(logQHotkey)
 

--- a/qhotkey.prc
+++ b/qhotkey.prc
@@ -1,6 +1,15 @@
 mac: LIBS += -framework Carbon
 else:win32: LIBS += -luser32
 else:unix {
-	QT += x11extras
+	equals(QT_MAJOR_VERSION, 6) {
+		lessThan(QT_VERSION, 6.2.0) {
+			error("Qt 6.2.0 or greater is required when using Qt6")
+		}
+	}
+	else {
+		lessThan(QT_MAJOR_VERSION, 6) {
+			QT += x11extras
+		}
+	}
 	LIBS += -lX11
 }


### PR DESCRIPTION
Added changes for Qt6. The source code can be used with either Qt5 or Qt6.

Works fine for me with Qt 6.2.0 RC2 and Qt 5.15.2+kde+r227.

Tested on Arch Linux x86_64 with gcc 11.1.0. No compiler warnings.

How to build:

CMake:
The `QT_MAJOR` CMake variable controls which major version of Qt is used for building. For example, specify `-DQT_MAJOR=6` as a CMake command line option for building with Qt6. Defaults to `5`, so nothing changes when using the default `cmake` invocation, as it will default to search/build for Qt5.

qmake:
Just build in the usual way with `qmake6 && make` or `qmake-qt5 && make`.

When building with Qt6 on GNU/Linux and similar UNIXes, the minimium required Qt version is 6.2.0, as Qt 6.1 and 6.0 lacks support for getting the X11 display.

Closes #49
