### PR TITLE
CMake: honor CMAKE_INSTALL_INCLUDEDIR in exported target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,12 @@ add_library(qhotkey ${SRC_FILES} ${MOC_HEADERS})
 add_library(QHotkey::QHotkey ALIAS qhotkey)
 target_link_libraries(qhotkey ${LIBS})
 
+include(GNUInstallDirs)
+
 target_include_directories(qhotkey
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/QHotkey>
-        $<INSTALL_INTERFACE:include>)
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 set_target_properties(qhotkey PROPERTIES
     SOVERSION ${PROJECT_VERSION_MAJOR}
@@ -71,7 +73,6 @@ if(QHOTKEY_EXAMPLES)
 endif()
 
 if(QHOTKEY_INSTALL)
-    include(GNUInstallDirs)
     set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/QHotkey)
 
     install(
@@ -82,7 +83,7 @@ if(QHOTKEY_INSTALL)
     install(FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/QHotkey/qhotkey.h
         ${CMAKE_CURRENT_SOURCE_DIR}/QHotkey/QHotkey
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     install(EXPORT QHotkeyConfig DESTINATION ${INSTALL_CONFIGDIR})
 
     export(TARGETS qhotkey FILE QHotkeyConfig.cmake)


### PR DESCRIPTION
Currently, when a user/packager builds and installs QHotkey system-wide with a custom `CMAKE_INSTALL_INCLUDEDIR`, the headers are in fact installed to the correct path chosen by `CMAKE_INSTALL_INCLUDEDIR`, but the CMake exported target becomes broken.

This is happening because the `include` directory is hardcoded in CMakeLists.txt. As a consequence, when a client application tries to access QHotkey by `find_package()`, the imported CMake target will tell that headers are installed at `<prefix>/include` due to the `include` hardcode, while in fact the headers will be installed at `<prefix>/CMAKE_INSTALL_INCLUDEDIR`.

In such explained situation, this will lead to the following compile error:
```
fatal error: QHotkey: No such file or directory
```

This commit removes the hardcode to the `include` directory in the CMake exported target, replacing it with `CMAKE_INSTALL_INCLUDEDIR` as the [CMake exporting documentation recommends](https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html#exporting-targets). This will let the user correctly access the headers when building a client application with a QHotkey package that is installed with a `CMAKE_INSTALL_INCLUDEDIR` different than `include`.

I think it's also a good idea to remove the ending slash from the `install(FILES <...>)` statement, as it should match exactly the same path that is being exported by `$<INSTALL_INTERFACE:CMAKE_INSTALL_INCLUDEDIR>`, as also shown on the same pointed documentation above.