### PR TITLE
CMake: use PRIVATE linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(QT_MAJOR 5 CACHE STRING "Qt major version to use")
 
 if(QT_MAJOR EQUAL 6)
-    find_package(Qt${QT_MAJOR} 6.2.0 COMPONENTS Core Widgets REQUIRED)
+    find_package(Qt${QT_MAJOR} 6.2.0 COMPONENTS Core Gui REQUIRED)
 else()
-    find_package(Qt${QT_MAJOR} COMPONENTS Core Widgets REQUIRED)
+    find_package(Qt${QT_MAJOR} COMPONENTS Core Gui REQUIRED)
 endif()
 
 if(QT_MAJOR GREATER_EQUAL 6)
@@ -25,37 +25,34 @@ else()
         QHotkey/qhotkey_p.h)
 endif()
 
-set(LIBS
-    Qt${QT_MAJOR}::Core
-    Qt${QT_MAJOR}::Widgets)
-
-set(SRC_FILES
-    QHotkey/qhotkey.cpp)
+add_library(qhotkey QHotkey/qhotkey.cpp ${MOC_HEADERS})
+add_library(QHotkey::QHotkey ALIAS qhotkey)
+target_link_libraries(qhotkey PUBLIC Qt${QT_MAJOR}::Core)
+target_link_libraries(qhotkey PRIVATE Qt${QT_MAJOR}::Gui)
 
 if(APPLE)
     find_library(CARBON_LIBRARY Carbon)
     mark_as_advanced(CARBON_LIBRARY)
 
-    set(SRC_FILES ${SRC_FILES} QHotkey/qhotkey_mac.cpp)
-    set(LIBS ${LIBS} ${CARBON_LIBRARY})
+    target_sources(qhotkey PRIVATE QHotkey/qhotkey_mac.cpp)
+    target_link_libraries(qhotkey PRIVATE ${CARBON_LIBRARY})
 elseif(WIN32)
-    set(SRC_FILES ${SRC_FILES} QHotkey/qhotkey_win.cpp)
+    target_sources(qhotkey PRIVATE QHotkey/qhotkey_win.cpp)
 else()
     find_package(X11 REQUIRED)
     if(QT_MAJOR GREATER_EQUAL 6)
-        set(LIBS ${LIBS} ${X11_LIBRARIES})
+        target_link_libraries(qhotkey PRIVATE ${X11_LIBRARIES})
     else()
         find_package(Qt${QT_MAJOR}X11Extras REQUIRED)
-        set(LIBS ${LIBS} ${X11_LIBRARIES} Qt${QT_MAJOR}::X11Extras)
+        target_link_libraries(qhotkey
+            PRIVATE
+                ${X11_LIBRARIES}
+                Qt${QT_MAJOR}::X11Extras)
     endif()
 
     include_directories(${X11_INCLUDE_DIR})
-    set(SRC_FILES ${SRC_FILES} QHotkey/qhotkey_x11.cpp)
+    target_sources(qhotkey PRIVATE QHotkey/qhotkey_x11.cpp)
 endif()
-
-add_library(qhotkey ${SRC_FILES} ${MOC_HEADERS})
-add_library(QHotkey::QHotkey ALIAS qhotkey)
-target_link_libraries(qhotkey ${LIBS})
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
According to [Qt6 documentation](https://doc.qt.io/qt-6/cmake-get-started.html), Qt libraries should use PRIVATE linking if the headers does not mention anything from Qt6::Widgets. This is the case with QHotkey, and the resulting shared libary libqhotkey.so does not link to libQt{5,6}Widgets.so. Qt5 docs does not say anything about link type, but most probably the logic is the same.

A practical consequence of PUBLIC linking in the current code, is that a Qt5 GNU/Linux (or UNIX) client application is forced to add X11Extras to `find_package()` when using QHotkey from a shared library (QHotkey built with `-DBUILD_SHARED_LIBS=ON`). This is mostly undesired.

By applying the change of this commit, Qt5 client applications using the shared library will be free of specifying X11Extras in
`find_package()`. And Qt5 client applications using the static library are unaffected in practical terms, as they will obviously
still need to specify X11Extras in `find_package()`, since the static object code will need to call X11Extras functions. Qt6
client applications will be also unaffected in practical terms, because there is no X11Extras in Qt6.

Tested on Arch Linux x86_64 with Qt 6.2.0 and Qt 5.15.2+kde+r228, each one with both shared and static library, and works fine for me.

Probably a test on Windows and MacOS would be good. I think it will have no impact there, at least not on the current code.