### PR TITLE
Qt6 support for Windows and Mac

### DIFF
--- a/QHotkey/qhotkey.cpp
+++ b/QHotkey/qhotkey.cpp
@@ -366,7 +366,7 @@ bool QHotkey::NativeShortcut::operator !=(QHotkey::NativeShortcut other) const
 		   valid != other.valid;
 }
 
-uint qHash(QHotkey::NativeShortcut key)
+QHOTKEY_HASH_SEED qHash(QHotkey::NativeShortcut key)
 {
 	return qHash(key.key) ^ qHash(key.modifier);
 }

--- a/QHotkey/qhotkey.h
+++ b/QHotkey/qhotkey.h
@@ -120,7 +120,7 @@ private:
 	bool _registered;
 };
 
-uint QHOTKEY_SHARED_EXPORT qHash(QHotkey::NativeShortcut key);
+QHOTKEY_HASH_SEED QHOTKEY_SHARED_EXPORT qHash(QHotkey::NativeShortcut key);
 QHOTKEY_HASH_SEED QHOTKEY_SHARED_EXPORT qHash(QHotkey::NativeShortcut key, QHOTKEY_HASH_SEED seed);
 
 QHOTKEY_SHARED_EXPORT Q_DECLARE_LOGGING_CATEGORY(logQHotkey)

--- a/QHotkey/qhotkey_mac.cpp
+++ b/QHotkey/qhotkey_mac.cpp
@@ -7,7 +7,7 @@ class QHotkeyPrivateMac : public QHotkeyPrivate
 {
 public:
 	// QAbstractNativeEventFilter interface
-	bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) Q_DECL_OVERRIDE;
+	bool nativeEventFilter(const QByteArray &eventType, void *message, _NATIVE_EVENT_RESULT *result) override;
 
 	static OSStatus hotkeyPressEventHandler(EventHandlerCallRef nextHandler, EventRef event, void* data);
 	static OSStatus hotkeyReleaseEventHandler(EventHandlerCallRef nextHandler, EventRef event, void* data);
@@ -33,7 +33,7 @@ bool QHotkeyPrivate::isPlatformSupported()
 bool QHotkeyPrivateMac::isHotkeyHandlerRegistered = false;
 QHash<QHotkey::NativeShortcut, EventHotKeyRef> QHotkeyPrivateMac::hotkeyRefs;
 
-bool QHotkeyPrivateMac::nativeEventFilter(const QByteArray &eventType, void *message, long *result)
+bool QHotkeyPrivateMac::nativeEventFilter(const QByteArray &eventType, void *message, _NATIVE_EVENT_RESULT *result)
 {
 	Q_UNUSED(eventType)
 	Q_UNUSED(message)

--- a/QHotkey/qhotkey_p.h
+++ b/QHotkey/qhotkey_p.h
@@ -7,6 +7,12 @@
 #include <QMutex>
 #include <QGlobalStatic>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	#define _NATIVE_EVENT_RESULT qintptr
+#else
+	#define _NATIVE_EVENT_RESULT long
+#endif
+
 class QHOTKEY_SHARED_EXPORT QHotkeyPrivate : public QObject, public QAbstractNativeEventFilter
 {
 	Q_OBJECT

--- a/QHotkey/qhotkey_win.cpp
+++ b/QHotkey/qhotkey_win.cpp
@@ -15,7 +15,7 @@ class QHotkeyPrivateWin : public QHotkeyPrivate
 public:
 	QHotkeyPrivateWin();
 	// QAbstractNativeEventFilter interface
-	bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) Q_DECL_OVERRIDE;
+	bool nativeEventFilter(const QByteArray &eventType, void *message, _NATIVE_EVENT_RESULT *result) override;
 
 protected:
 	void pollForHotkeyRelease();
@@ -42,7 +42,7 @@ bool QHotkeyPrivate::isPlatformSupported()
 	return true;
 }
 
-bool QHotkeyPrivateWin::nativeEventFilter(const QByteArray &eventType, void *message, long *result)
+bool QHotkeyPrivateWin::nativeEventFilter(const QByteArray &eventType, void *message, _NATIVE_EVENT_RESULT *result)
 {
 	Q_UNUSED(eventType)
 	Q_UNUSED(result)

--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -3,13 +3,9 @@
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
 	#include <QGuiApplication>
-	
-	#define _NATIVE_EVENT_RESULT qintptr
 #else
 	#include <QDebug>
 	#include <QX11Info>
-	
-	#define _NATIVE_EVENT_RESULT long
 #endif
 
 #include <QThreadStorage>


### PR DESCRIPTION
This follows commit 25f2184.

On Windows, changing the return value of the `qHash()` variant that takes one argument fixes the following warning on MSVC 2019:

```
qhotkey.cpp:(371,45): warning C4267: 'return': conversion from 'size_t' to 'uint', possible loss of data
```

After this change, it also works fine for me on Arch Linux x86_64 with Qt 6.2.0.

Mac changes are untested.