### PR TITLE
CMake: add package version config file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - "releases/**"
     paths-ignore:
       - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
 
 jobs:
   build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 
-project(qhotkey VERSION 1.2.2 LANGUAGES CXX)
+project(qhotkey VERSION 1.4.2 LANGUAGES CXX)
 
 option(QHOTKEY_EXAMPLES "Build examples" OFF)
 option(QHOTKEY_INSTALL "Enable install rule" ON)
@@ -52,9 +52,18 @@ target_include_directories(qhotkey
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/QHotkey>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
+include(CMakePackageConfigHelpers)
+
 set_target_properties(qhotkey PROPERTIES
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    VERSION ${PROJECT_VERSION})
+    VERSION ${PROJECT_VERSION}
+    INTERFACE_QHotkey_MAJOR_VERSION ${PROJECT_VERSION_MAJOR}
+    COMPATIBLE_INTERFACE_STRING QHotkey_MAJOR_VERSION)
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/QHotkeyConfigVersion.cmake
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY AnyNewerVersion)
 
 if(QHOTKEY_EXAMPLES)
     add_subdirectory(HotkeyTest)
@@ -72,6 +81,9 @@ if(QHOTKEY_INSTALL)
         ${CMAKE_CURRENT_SOURCE_DIR}/QHotkey/qhotkey.h
         ${CMAKE_CURRENT_SOURCE_DIR}/QHotkey/QHotkey
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/QHotkeyConfigVersion.cmake
+        DESTINATION ${INSTALL_CONFIGDIR})
     install(EXPORT QHotkeyConfig DESTINATION ${INSTALL_CONFIGDIR})
 
     export(TARGETS qhotkey FILE QHotkeyConfig.cmake)


### PR DESCRIPTION
The CMake invocation fails when calling `find_package()` on a client application if the call specifies of the minimum desired version.

For example, `find_package(QHotkey 1.4.2 REQUIRED)` gives the following output:

```
CMake Error at CMakeLists.txt:141 (find_package):
  Could not find a configuration file for package "QHotkey" that is
  compatible with requested version "1.4.2".

  The following configuration files were considered but not accepted:

    /usr/lib/qhotkey-qt6/cmake/QHotkey/QHotkeyConfig.cmake, version: unknown
    /usr/lib64/cmake/QHotkey/QHotkeyConfig.cmake, version: unknown
    /usr/lib/cmake/QHotkey/QHotkeyConfig.cmake, version: unknown
    /lib64/cmake/QHotkey/QHotkeyConfig.cmake, version: unknown
    /lib/cmake/QHotkey/QHotkeyConfig.cmake, version: unknown
```

That's because the CMake package is lacking a version config file. By adding this file, client applications can have proper version checking support.

This commit also updates the CMake project version to the current 1.4.2, as it was 1.2.2.

Tested on Arch Linux x86_64 with Qt 6.2.0 and Qt 5.15.2+kde+r228.