### PR TITLE
Fix the shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 add_library(qhotkey QHotkey/qhotkey.cpp)
 add_library(QHotkey::QHotkey ALIAS qhotkey)
+add_definitions(-DQHOTKEY_LIBRARY)
 target_link_libraries(qhotkey PUBLIC Qt${QT_MAJOR}::Core)
 target_link_libraries(qhotkey PRIVATE Qt${QT_MAJOR}::Gui)
 

--- a/QHotkey/QHotkey.pro
+++ b/QHotkey/QHotkey.pro
@@ -6,7 +6,7 @@ VERSION = 1.2.1
 
 include(../qhotkey.pri)
 
-DEFINES += QHOTKEY_LIB QHOTKEY_LIB_BUILD
+DEFINES += QHOTKEY_LIBRARY
 
 # use INSTALL_ROOT to modify the install location
 headers.files = $$PUBLIC_HEADERS

--- a/QHotkey/qhotkey.h
+++ b/QHotkey/qhotkey.h
@@ -6,14 +6,10 @@
 #include <QPair>
 #include <QLoggingCategory>
 
-#ifdef QHOTKEY_LIB
-	#ifdef QHOTKEY_LIB_BUILD
-		#define QHOTKEY_SHARED_EXPORT Q_DECL_EXPORT
-	#else
-		#define QHOTKEY_SHARED_EXPORT Q_DECL_IMPORT
-	#endif
+#ifdef QHOTKEY_LIBRARY
+	#define QHOTKEY_SHARED_EXPORT Q_DECL_EXPORT
 #else
-	#define QHOTKEY_SHARED_EXPORT
+	#define QHOTKEY_SHARED_EXPORT Q_DECL_IMPORT
 #endif
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)


### PR DESCRIPTION
Linking client applications to the shared library fails with compilers that do not automatically manage the symbols, like with MSVC 2019.

It looks like that using two definitions to manage which `Q_DECL_<...>` to use (if `Q_DECL_EXPORT` or `Q_DECL_IMPORT`)
is hiding the imports on the client application side. When nothing is defined (like on client applications), the `Q_DECL_IMPORT` seems to become missing, leading to a link error.

It also seems unnecessary and more complicated to use two definitions, while we can use just one to achieve the desired result.

This solves the issue in a pure C++ way, like recommended on the Qt shared library documentation.

Note: CMake documentation states that `add_definitions()` was superseded by `add_compile_definitions()`, but this newer counterpart requires CMake 3.14 or later. Used `add_definitions()` due to CMake 3.1 minimum requirement on QHotkey.

Tested on Arch Linux x86_64 with Qt 6.2.0 and Qt 5.15.2+kde+r234 (both with gcc 11.1.0), and also on Windows 7 with Qt 5.15.2 and MSVC 2019. The shared library builds fine without any modifications, and the client application example also links fine.

Fixes #58