### PR TITLE
Fix shared library build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,16 +45,27 @@ jobs:
         with:
           version: ${{ matrix.qt_version }}
 
-      - name: Build with CMake
+      - name: Build with CMake as static
         run: |
           cmake . -D QHOTKEY_EXAMPLES=ON ${{ matrix.additional_arguments }}
+          cmake --build .
+
+      - name: Build with CMake as shared
+        run: |
+          cmake . -D BUILD_SHARED_LIBS=ON -D QHOTKEY_EXAMPLES=ON ${{ matrix.additional_arguments }}
           cmake --build .
 
       - name: Setup MSVC environment for QMake
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Build with QMake
+      - name: Build with QMake as static
         working-directory: HotkeyTest
         run: |
           qmake
+          ${{ matrix.make }}
+
+      - name: Build with QMake as shared
+        working-directory: HotkeyTest
+        run: |
+          qmake "DEFINES+=QHOTKEY_SHARED QHOTKEY_LIBRARY"
           ${{ matrix.make }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ add_library(QHotkey::QHotkey ALIAS qhotkey)
 target_link_libraries(qhotkey PUBLIC Qt${QT_MAJOR}::Core)
 target_link_libraries(qhotkey PRIVATE Qt${QT_MAJOR}::Gui)
 
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(qhotkey PRIVATE QHOTKEY_LIBRARY)
+    target_compile_definitions(qhotkey PUBLIC QHOTKEY_SHARED)
+endif()
+
 if(APPLE)
     find_library(CARBON_LIBRARY Carbon)
     mark_as_advanced(CARBON_LIBRARY)

--- a/QHotkey/QHotkey.pro
+++ b/QHotkey/QHotkey.pro
@@ -6,7 +6,7 @@ VERSION = 1.2.1
 
 include(../qhotkey.pri)
 
-DEFINES += QHOTKEY_LIB QHOTKEY_LIB_BUILD
+DEFINES += QHOTKEY_SHARED QHOTKEY_LIBRARY
 
 # use INSTALL_ROOT to modify the install location
 headers.files = $$PUBLIC_HEADERS

--- a/QHotkey/qhotkey.h
+++ b/QHotkey/qhotkey.h
@@ -6,14 +6,14 @@
 #include <QPair>
 #include <QLoggingCategory>
 
-#ifdef QHOTKEY_LIB
-	#ifdef QHOTKEY_LIB_BUILD
-		#define QHOTKEY_SHARED_EXPORT Q_DECL_EXPORT
-	#else
-		#define QHOTKEY_SHARED_EXPORT Q_DECL_IMPORT
-	#endif
+#ifdef QHOTKEY_SHARED
+#	ifdef QHOTKEY_LIBRARY
+#		define QHOTKEY_EXPORT Q_DECL_EXPORT
+#	else
+#		define QHOTKEY_EXPORT Q_DECL_IMPORT
+#	endif
 #else
-	#define QHOTKEY_SHARED_EXPORT
+#	define QHOTKEY_EXPORT
 #endif
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -23,7 +23,7 @@
 #endif
 
 //! A class to define global, systemwide Hotkeys
-class QHOTKEY_SHARED_EXPORT QHotkey : public QObject
+class QHOTKEY_EXPORT QHotkey : public QObject
 {
 	Q_OBJECT
 	//! @private
@@ -36,7 +36,7 @@ class QHOTKEY_SHARED_EXPORT QHotkey : public QObject
 
 public:
 	//! Defines shortcut with native keycodes
-	class QHOTKEY_SHARED_EXPORT NativeShortcut {
+	class QHOTKEY_EXPORT NativeShortcut {
 	public:
 		//! The native keycode
 		quint32 key;
@@ -120,10 +120,10 @@ private:
 	bool _registered;
 };
 
-QHOTKEY_HASH_SEED QHOTKEY_SHARED_EXPORT qHash(QHotkey::NativeShortcut key);
-QHOTKEY_HASH_SEED QHOTKEY_SHARED_EXPORT qHash(QHotkey::NativeShortcut key, QHOTKEY_HASH_SEED seed);
+QHOTKEY_HASH_SEED QHOTKEY_EXPORT qHash(QHotkey::NativeShortcut key);
+QHOTKEY_HASH_SEED QHOTKEY_EXPORT qHash(QHotkey::NativeShortcut key, QHOTKEY_HASH_SEED seed);
 
-QHOTKEY_SHARED_EXPORT Q_DECLARE_LOGGING_CATEGORY(logQHotkey)
+QHOTKEY_EXPORT Q_DECLARE_LOGGING_CATEGORY(logQHotkey)
 
 Q_DECLARE_METATYPE(QHotkey::NativeShortcut)
 

--- a/QHotkey/qhotkey_p.h
+++ b/QHotkey/qhotkey_p.h
@@ -13,7 +13,7 @@
 	#define _NATIVE_EVENT_RESULT long
 #endif
 
-class QHOTKEY_SHARED_EXPORT QHotkeyPrivate : public QObject, public QAbstractNativeEventFilter
+class QHOTKEY_EXPORT QHotkeyPrivate : public QObject, public QAbstractNativeEventFilter
 {
 	Q_OBJECT
 


### PR DESCRIPTION
Fixes the build as a shared library for CMake and adds tests for the CI.
I also changed macro names according to the [Qt example](https://doc.qt.io/qt-5/sharedlibrary.html). The difference from the example is that we have an extra define `QHOTKEY_SHARED` (previously named as `QHOTKEY_LIB`, I just renamed it to avoid confusion) because we want to have an option to build the library statically. In this case `QHOTKEY_EXPORT` should be defined as an empty macro.