### PR TITLE
Fix bug for get natice keycode failed in mac

### DIFF
--- a/QHotkey/qhotkey_mac.cpp
+++ b/QHotkey/qhotkey_mac.cpp
@@ -134,7 +134,7 @@ quint32 QHotkeyPrivateMac::nativeKeycode(Qt::Key keycode, bool &ok)
 	UTF16Char ch = keycode;
 
 	CFDataRef currentLayoutData;
-	TISInputSourceRef currentKeyboard = TISCopyCurrentKeyboardInputSource();
+	TISInputSourceRef currentKeyboard = TISCopyCurrentASCIICapableKeyboardLayoutInputSource();
 
 	if (currentKeyboard == NULL)
 		return 0;


### PR DESCRIPTION
TISCopyCurrentKeyboardInputSource will return null when using Chinese input method.
Use TISCopyCurrentASCIICapableKeyboardLayoutInputSource instead.

This is the fist time for me to submit a PR. 
Maybe I should do like this.