### PR TITLE
Attempt to fix the issue #85: the `released` signal will not be properly emitted when pressing multiple hotkeys at the same time on windows

### DIFF
--- a/QHotkey/qhotkey_win.cpp
+++ b/QHotkey/qhotkey_win.cpp
@@ -63,12 +63,12 @@ bool QHotkeyPrivateWin::nativeEventFilter(const QByteArray &eventType, void *mes
 
 void QHotkeyPrivateWin::pollForHotkeyRelease()
 {
-	auto it = std::remove_if(this->polledShortcuts.begin(), this->polledShortcuts.end(),
-							 [this](const QHotkey::NativeShortcut &shortcut) {
-								 bool pressed = (GetAsyncKeyState(shortcut.key) & (1 << 15)) != 0;
-								 if (!pressed) this->releaseShortcut(shortcut);
-								 return !pressed;
-							 });
+	auto it = std::remove_if(this->polledShortcuts.begin(), this->polledShortcuts.end(), [this](const QHotkey::NativeShortcut &shortcut) {
+		bool pressed = (GetAsyncKeyState(shortcut.key) & (1 << 15)) != 0;
+		if (!pressed)
+			this->releaseShortcut(shortcut);
+		return !pressed;
+	});
 	this->polledShortcuts.erase(it, this->polledShortcuts.end());
 	if (this->polledShortcuts.empty())
 		this->pollTimer.stop();


### PR DESCRIPTION
Attempt to fix the issue #85  by maintaining all the pressed hotkeys in a `QList` and use `std::remove_if` to emit the signal and remove the released hotkeys from the `QList`.