### PR TITLE
include <QtX11Extras/QX11Info>

### DIFF
--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -5,7 +5,7 @@
 	#include <QGuiApplication>
 #else
 	#include <QDebug>
-	#include <QX11Info>
+	#include <QtX11Extras/QX11Info>
 #endif
 
 #include <QThreadStorage>


### PR DESCRIPTION
Systems such as openSUSE Tumbleweed cannot find QX11Info otherwise.

Relates to https://github.com/crow-translate/crow-translate/pull/645