### PR TITLE
X11 Qt6: fix segmentation fault when running under Wayland

### DIFF
--- a/QHotkey/qhotkey_x11.cpp
+++ b/QHotkey/qhotkey_x11.cpp
@@ -132,7 +132,10 @@ quint32 QHotkeyPrivateX11::nativeKeycode(Qt::Key keycode, bool &ok)
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
 	const QNativeInterface::QX11Application *x11Interface = qGuiApp->nativeInterface<QNativeInterface::QX11Application>();
-	Display *display = x11Interface->display();
+	Display *display = nullptr;
+
+	if (x11Interface)
+		display = x11Interface->display();
 #else
 	const bool x11Interface = QX11Info::isPlatformX11();
 	Display *display = QX11Info::display();


### PR DESCRIPTION
Under Wayland, `QGuiApplication::nativeInterface()` seems to return a null pointer. At least, this happens in Plasma 6.0.3 with Qt 6.6.2. A segmentation fault occurs when dereferencing the null pointer for obtaining the X11 display.

Checking for a valid pointer in `x11Interface` variable before acquiring the X11 display is safer and avoids this problem.