### PR TITLE
Increase cmake_minimum_required to mute warings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 project(qhotkey
     VERSION 1.5.0


### PR DESCRIPTION
CMake 3.10 has been released 8 years ago and according to the warnings its compatibility below that version will be removed in newer CMake versions.