### PR TITLE
Add compatibility with QT_NO_KEYWORDS macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(qhotkey QHotkey/qhotkey.cpp)
 add_library(QHotkey::QHotkey ALIAS qhotkey)
 target_link_libraries(qhotkey PUBLIC Qt${QT_DEFAULT_MAJOR_VERSION}::Core Qt${QT_DEFAULT_MAJOR_VERSION}::Gui)
 
+target_compile_definitions(qhotkey PRIVATE QT_NO_SIGNALS_SLOTS_KEYWORDS)
+
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(qhotkey PRIVATE QHOTKEY_LIBRARY)
     target_compile_definitions(qhotkey PUBLIC QHOTKEY_SHARED)

--- a/QHotkey/qhotkey.h
+++ b/QHotkey/qhotkey.h
@@ -88,7 +88,7 @@ public:
 	//! Get the current native shortcut
 	NativeShortcut currentNativeShortcut() const;
 
-public slots:
+public Q_SLOTS:
 	//! @writeAcFn{QHotkey::registered}
 	bool setRegistered(bool registered);
 
@@ -102,7 +102,7 @@ public slots:
 	//! Set this hotkey to a native shortcut
 	bool setNativeShortcut(QHotkey::NativeShortcut nativeShortcut, bool autoRegister = false);
 
-signals:
+Q_SIGNALS:
 	//! Will be emitted if the shortcut is pressed
 	void activated(QPrivateSignal);
 


### PR DESCRIPTION
The Qt documentation [recommends](https://doc.qt.io/qt-6/signalsandslots.html#signals-and-slots-in-qt-based-libraries) not using Qt keywords in the public API of Qt libraries, specially the `signals` and `slots` Qt keywords.

Without this, client applications that are compiled with the [`QT_NO_KEYWORDS`](https://doc.qt.io/qt-6/qtglobal.html#QT_NO_KEYWORDS) macro (or that are compiled in conjunction with other libraries that also defines the same Qt keywords) will fail to build.

The [`QT_NO_SIGNALS_SLOTS_KEYWORDS`](https://doc.qt.io/qt-6/signalsandslots.html#signals-and-slots-in-qt-based-libraries) macro assures that the library is not using `signals` and `slots` Qt keywords, since it will fail to build when they are used. Useful for code sanity and for avoiding future pull requests that may try to use these Qt keywords.
